### PR TITLE
Dont install test package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     download_url=(
         'https://github.com/geopy/geopy/archive/%s.tar.gz' % version
     ),
-    packages=find_packages(exclude=["test"]),
+    packages=find_packages(exclude=["*test*"]),
     install_requires=INSTALL_REQUIRES,
     tests_require=TESTS_REQUIRES,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     download_url=(
         'https://github.com/geopy/geopy/archive/%s.tar.gz' % version
     ),
-    packages=find_packages(),
+    packages=find_packages(exclude=["test"]),
     install_requires=INSTALL_REQUIRES,
     tests_require=TESTS_REQUIRES,
     extras_require={


### PR DESCRIPTION
Prevent namespace collision between geopy test module and standard's library's
